### PR TITLE
feat: add syntax highlights in markdown codeblocks

### DIFF
--- a/example/abnf-lang-codeblock.md
+++ b/example/abnf-lang-codeblock.md
@@ -1,0 +1,69 @@
+# Example of ABNF highlighting in MarkDown
+
+This example is taken from [`./abnf-lang.abnf`](./abnf-lang.abnf).
+
+```abnf
+;;
+;; ABNF Definition of ABNF from RFC 5234
+;;
+
+rulelist       =  1*( rule / (*c-wsp c-nl) )
+
+rule           =  rulename defined-as elements c-nl
+                      ; continues if next line starts
+                      ;  with white space
+
+rulename       =  ALPHA *(ALPHA / DIGIT / "-")
+
+defined-as     =  *c-wsp ("=" / "=/") *c-wsp
+                      ; basic rules definition and
+                      ;  incremental alternatives
+
+elements       =  alternation *c-wsp
+
+c-wsp          =  WSP / (c-nl WSP)
+
+c-nl           =  comment / CRLF
+                      ; comment or newline
+
+comment        =  ";" *(WSP / VCHAR) CRLF
+
+alternation    =  concatenation
+                  *(*c-wsp "/" *c-wsp concatenation)
+
+concatenation  =  repetition *(1*c-wsp repetition)
+
+repetition     =  [repeat] element
+
+repeat         =  1*DIGIT / (*DIGIT "*" *DIGIT)
+
+element        =  rulename / group / option /
+                  char-val / num-val / prose-val
+
+group          =  "(" *c-wsp alternation *c-wsp ")"
+
+option         =  "[" *c-wsp alternation *c-wsp "]"
+
+char-val       =  DQUOTE *(%x20-21 / %x23-7E) DQUOTE
+                      ; quoted string of SP and VCHAR
+                      ;  without DQUOTE
+
+num-val        =  "%" (bin-val / dec-val / hex-val)
+
+bin-val        =  "b" 1*BIT
+                  [ 1*("." 1*BIT) / ("-" 1*BIT) ]
+                      ; series of concatenated bit values
+                      ;  or single ONEOF range
+
+dec-val        =  "d" 1*DIGIT
+                  [ 1*("." 1*DIGIT) / ("-" 1*DIGIT) ]
+
+hex-val        =  "x" 1*HEXDIG
+                  [ 1*("." 1*HEXDIG) / ("-" 1*HEXDIG) ]
+
+prose-val      =  "<" *(%x20-3D / %x3F-7E) ">"
+                      ; bracketed string of SP and VCHAR
+                      ;  without angles
+                      ; prose description, to be used as
+                      ;  last resort
+```

--- a/package.json
+++ b/package.json
@@ -32,6 +32,16 @@
         "language": "abnf",
         "scopeName": "source.abnf",
         "path": "./syntaxes/abnf.tmLanguage"
+      },
+      {
+        "scopeName": "markdown.abnf.codeblock",
+        "path": "./syntaxes/codeblock-abnf.json",
+        "injectTo": [
+          "text.html.markdown"
+        ],
+        "embeddedLanguages": {
+          "meta.embedded.block.abnf": "abnf"
+        }
       }
     ]
   }

--- a/syntaxes/codeblock-abnf.json
+++ b/syntaxes/codeblock-abnf.json
@@ -1,0 +1,28 @@
+{
+    "fileTypes": [],
+    "injectionSelector": "L:markup.fenced_code.block.markdown",
+    "patterns": [
+        {
+            "include": "#abnf-code-block"
+        }
+    ],
+    "repository": {
+        "abnf-code-block": {
+            "begin": "\\b(abnf)\\b(\\s+[^`~]*)?$",
+            "end": "(^|\\G)(?=\\s*[`~]{3,}\\s*$)",
+            "patterns": [
+                {
+                    "begin": "(^|\\G)(\\s*)(.*)",
+                    "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+                    "contentName": "meta.embedded.block.abnf",
+                    "patterns": [
+                        {
+                            "include": "source.abnf"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "scopeName": "markdown.abnf.codeblock"
+}


### PR DESCRIPTION
# What

This PR adds support for syntax highlighting in MarkDown code blocks with `abnf` type.  
Closes #1. 

## How

- Followed the documentation from <https://code.visualstudio.com/api/language-extensions/syntax-highlight-guide#injection-grammars>.
- Got inspiration from <https://github.com/JustusAdam/language-haskell/blob/master/syntaxes/codeblock-haskell.json>.

## Example

Running the extension in a developer host: 

> ![2022-12-08 22 10 12](https://user-images.githubusercontent.com/12134172/206568108-15279960-bbc0-4180-b9b5-2f19b53f61c2.gif)

